### PR TITLE
Update Horse.OctetStream.pas (Compatibilidade Delphi XE 7)

### DIFF
--- a/src/Horse.OctetStream.pas
+++ b/src/Horse.OctetStream.pas
@@ -45,14 +45,18 @@ var
 begin
   AStream.Clear;
   {$IF DEFINED(FPC)}
-   LStringStream := TStringStream.Create(ARequest.RawWebRequest.Content);
-   try
-     LStringStream.SaveToStream(AStream);
-   finally
-     LStringStream.Free;
-   end;
+  LStringStream := TStringStream.Create(ARequest.RawWebRequest.Content);
+  try
+    LStringStream.SaveToStream(AStream);
+  finally
+    LStringStream.Free;
+  end;
   {$ELSE}
-  ARequest.RawWebRequest.ReadTotalContent;
+  {$IF CompilerVersion <= 28}
+    Assert(Length(ARequest.RawWebRequest.RawContent) = ARequest.RawWebRequest.ContentLength);
+  {$ELSE}
+    ARequest.RawWebRequest.ReadTotalContent;
+  {$ENDIF}
 
   ContentLength := ARequest.RawWebRequest.ContentLength;
   while ContentLength > 0 do


### PR DESCRIPTION
Na procedure procedure GetAllDataAsStream(ARequest: THorseRequest; AStream: TMemoryStream);

Neste processo "ARequest.RawWebRequest.ReadTotalContent;", não tem este recurso no Delphi XE7, consegui solucionar a situação alterando o processo para.

{$IF CompilerVersion <= 28}
Assert(Length(ARequest.RawWebRequest.RawContent) = ARequest.RawWebRequest.ContentLength);
{$ELSE}
ARequest.RawWebRequest.ReadTotalContent;
{$ENDIF}

Referência: danieleteti/delphimvcframework#200