### PR TITLE
Correção para compatibilidade com exportação de módulo apache

### DIFF
--- a/src/Horse.OctetStream.pas
+++ b/src/Horse.OctetStream.pas
@@ -45,7 +45,7 @@ implementation
 
 procedure GetAllDataAsStream(ARequest: THorseRequest; AStream: TMemoryStream);
 var
-{$IF DEFINED(FPC)}
+{$IF DEFINED(FPC) OR DEFINED(HORSE_APACHE)}
   LStringStream: TStringStream;
 {$ELSE}
   BytesRead, ContentLength: Integer;
@@ -53,8 +53,12 @@ var
 {$ENDIF}
 begin
   AStream.Clear;
-  {$IF DEFINED(FPC)}
+  {$IF DEFINED(FPC) OR DEFINED(HORSE_APACHE)}
+  {$IF DEFINED(HORSE_APACHE)}
+  LStringStream := TStringStream.Create(ARequest.RawWebRequest.RawContent);
+  {$ELSE}
   LStringStream := TStringStream.Create(ARequest.RawWebRequest.Content);
+  {$ENDIF}
   try
     LStringStream.SaveToStream(AStream);
   finally


### PR DESCRIPTION
Olá, tudo bem? Obtive um erro de compatibilidade na exportação para módulo Apache, a requisição octet-stream estava sendo recebida com o conteúdo do corpo em branco. Realizei essa pequena correção, segue para vossa análise. 

Segue prints.

**Código do meu módulo:**
![Print2](https://github.com/HashLoad/horse-octet-stream/assets/2487768/eae2ae2f-2441-43dc-bac6-8dec2c418af7)

**Requisição com o Postman antes da correção:**
![Print1](https://github.com/HashLoad/horse-octet-stream/assets/2487768/a64ef302-c492-44dd-a75a-2a259ca10c89)

**Requisição após a correção:**
![Print3](https://github.com/HashLoad/horse-octet-stream/assets/2487768/99a49326-62c5-4696-9ffb-84e3a066369f)


